### PR TITLE
fix event param of viewport-coordinates example code

### DIFF
--- a/examples/viewport-coordinates/index.html
+++ b/examples/viewport-coordinates/index.html
@@ -132,7 +132,7 @@
 <p>Here's a code sample coordinate conversion, based on clicks: 
 <pre>// Assuming we have an OpenSeadragon Viewer called "viewer", we can catch the clicks 
 // with addHandler like so:
-viewer.addHandler('canvas-click', function(target, info) {
+viewer.addHandler('canvas-click', function(event) {
     // The canvas-click event gives us a position in web coordinates.
     var webPoint = event.position;
 


### PR DESCRIPTION
This is a trivial fix to the viewport coordinate example, as discussed in openseadragon/openseadragon#809