### PR TITLE
escape HTML in documentation

### DIFF
--- a/docs/OpenSeadragon.Viewer.html
+++ b/docs/OpenSeadragon.Viewer.html
@@ -15611,7 +15611,7 @@ Viewer which raised the event.</td>
     <div class="description">
         This event is fired just before the tile is drawn giving the application a chance to alter the image.
 
-NOTE: This event is only fired when the drawer is using a <canvas>.
+NOTE: This event is only fired when the drawer is using a &lt;canvas&gt;.
     </div>
     
 

--- a/docs/global.html
+++ b/docs/global.html
@@ -12292,7 +12292,7 @@ Viewer which raised the event.</td>
     <div class="description">
         This event is fired just before the tile is drawn giving the application a chance to alter the image.
 
-NOTE: This event is only fired when the drawer is using a <canvas>.
+NOTE: This event is only fired when the drawer is using a &lt;canvas&gt;.
     </div>
     
 


### PR DESCRIPTION
Escaped two instances of "&lt;canvas&gt;".