### PR TITLE
Fix dead link to GeoTIFFTileSource demo

### DIFF
--- a/index.html
+++ b/index.html
@@ -145,7 +145,7 @@
         </p>
         <ul>
             <li>
-                <a href="https://pearcetm.github.io/GeoTIFFTileSource/demo.html">
+                <a href="https://pearcetm.github.io/GeoTIFFTileSource/demo/demo.html">
                     GeoTIFFTileSource - view TIFF-compatible files via geotiff.js
                 </a>
             </li>


### PR DESCRIPTION
https://pearcetm.github.io/GeoTIFFTileSource/demo.html
is now
https://pearcetm.github.io/GeoTIFFTileSource/demo/demo.html